### PR TITLE
bumping minimum php version to 7.1, removing 7.0 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ jobs:
     - php: nightly
     - php: 7.3
   include:
-    - php: 7
     - php: 7.1
     - php: 7.2
     - php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "php": ">=7.0"
+        "php": ">=7.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",
-        "localheinz/composer-normalize": "0.2.0 || ^1.0",
+        "localheinz/composer-normalize": "^1.0",
         "phpro/grumphp": "^0.14.3",
         "phpunit/phpunit": "^6.5 || ^7.3"
     },


### PR DESCRIPTION
PHP 7.0 is EOL now, so removing support for it (this will be a 2.0 release), if php 7.0 is necessary, can use 1.0.