### PR TITLE
adding php 7.1 php-cs-fixer rules

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -11,6 +11,8 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
         '@PHP70Migration' => true,
+        '@PHP71Migration' => true,
+        '@PHP71Migration:risky' => true,
         '@PHPUnit60Migration:risky' => true,
         'binary_operator_spaces' => [
             'default' => 'align_single_space_minimal',

--- a/src/BrowserAge/Browser.php
+++ b/src/BrowserAge/Browser.php
@@ -11,7 +11,7 @@ class Browser
     protected $platform;
     protected $minimumStability = BrowserAge::STABILITY_STABLE;
 
-    public function setVersion($version)
+    public function setVersion($version): void
     {
         $this->version = $version;
     }

--- a/src/BrowserAge/BrowserAge.php
+++ b/src/BrowserAge/BrowserAge.php
@@ -4,8 +4,8 @@ namespace BrowserAge;
 
 class BrowserAge
 {
-    const STABILITY_BETA   = 100;
-    const STABILITY_STABLE = 200;
+    public const STABILITY_BETA   = 100;
+    public const STABILITY_STABLE = 200;
 
     protected $minimumStability = self::STABILITY_STABLE;
     protected $browser;
@@ -127,7 +127,7 @@ class BrowserAge
         }
     }
 
-    public function setBrowser(Browser $browser, $version = null)
+    public function setBrowser(Browser $browser, $version = null): void
     {
         $this->browser = $browser;
         if ($version !== null) {
@@ -135,7 +135,7 @@ class BrowserAge
         }
     }
 
-    public function setPlatform(Platform $platform, $version = null)
+    public function setPlatform(Platform $platform, $version = null): void
     {
         $this->platform = $platform;
         if ($version !== null) {
@@ -143,7 +143,7 @@ class BrowserAge
         }
     }
 
-    public function setMinimumStability($stability)
+    public function setMinimumStability($stability): void
     {
         $this->minimumStability = $stability;
     }

--- a/src/BrowserAge/Platform.php
+++ b/src/BrowserAge/Platform.php
@@ -7,7 +7,7 @@ class Platform
     protected $version;
     protected $name;
 
-    public function setVersion($version)
+    public function setVersion($version): void
     {
         $this->version = $version;
     }

--- a/tests/BrowserAgeTest/VersionTest.php
+++ b/tests/BrowserAgeTest/VersionTest.php
@@ -22,7 +22,7 @@ class VersionTest extends TestCase
     /**
      * @dataProvider dataProviderVersions
      */
-    public function testVersionAging($browser, $platform, $version, $expected)
+    public function testVersionAging($browser, $platform, $version, $expected): void
     {
         $ba = new BrowserAge($browser, $version, $platform);
 


### PR DESCRIPTION
Now that php 7.1+ is required, can add php cs 7.1 fixers.

Ran fixers.